### PR TITLE
Add fallback when status code has no assigned status text

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,16 @@
 		"ext-curl": "*",
 		"symfony/event-dispatcher": "~2.6"
 	},
+	"require-dev": {
+		"phpunit/phpunit": "5.5.*"
+	},
 	"suggest": {
 		"predis/predis": "For caching purposes"
 	},
 	"autoload": {
 		"psr-4": {
-			"Proxy\\": "src/"
+			"Proxy\\": "src/",
+			"Proxy\\Tests\\": "tests/"
 		},
 		"files": [
 			"src/helpers.php"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="./vendor/autoload.php">
+    <testsuites>
+        <testsuite name="PhpProxy">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -50,60 +50,72 @@ class Response {
 		504 => 'Gateway Time-out',
 		505 => 'Unsupported Version'
     );
-	
+
+    public $statusCodeGroups = array(
+        1 => 'Informational',
+        2 => 'Success',
+        3 => 'Redirect',
+        4 => 'Client error',
+        5 => 'Server error'
+    );
+
 	public $status;
-	
+
 	public $headers;
-	
+
 	private $content;
-	
+
 	// getHeaderLines
 	public function __construct($content = '', $status = 200, $headers = array()){
-	
+
 		$this->headers = new ParamStore($headers);
-		
+
 		$this->setContent($content);
 		$this->setStatusCode($status);
 	}
-	
+
 	public function setStatusCode($code){
 		$this->status = $code;
 	}
-	
+
 	public function getStatusCode(){
 		return $this->status;
 	}
-	
+
 	public function getStatusText(){
-		return $this->statusCodes[$this->getStatusCode()];
+	    $statusCode = $this->getStatusCode();
+
+        return isset($this->statusCodes[$statusCode])
+            ? $this->statusCodes[$statusCode]
+            : $this->getDefaultStatusText($statusCode);
 	}
-	
+
 	public function setContent($content){
 		$this->content = (string)$content;
 	}
-	
+
 	public function getContent(){
 		return $this->content;
 	}
-	
+
 	public function sendHeaders(){
-	
+
 		if(headers_sent()){
 			return;
 		}
-		
+
 		header(sprintf('HTTP/1.1 %s %s', $this->status, $this->getStatusText()), true, $this->status);
-		
+
 		foreach($this->headers->all() as $name => $value){
-		
+
 			/*
-				Multiple message-header fields with the same field-name MAY be present in a message 
+				Multiple message-header fields with the same field-name MAY be present in a message
 				if and only if the entire field-value for that header field is defined as a comma-separated list
 				http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
 			*/
-			
+
 			$values = is_array($value) ? $value : array($value);
-			
+
 			// false = do not replace previous identical header
 			foreach($values as $value){
 				header("{$name}: {$value}", false);
@@ -116,6 +128,13 @@ class Response {
 		echo $this->content;
 	}
 
+    protected function getDefaultStatusText($statusCode){
+        $statusCodeGroup = substr($statusCode, 0, 1);
+
+        return isset($this->statusCodeGroups[$statusCodeGroup])
+            ? $this->statusCodeGroups[$statusCodeGroup]
+            : 'Unknown';
+    }
 }
 
 ?>

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -41,6 +41,7 @@ class Response {
 		415 => 'Unsupported Media Type',
 		416 => 'Requested range not satisfiable',
 		417 => 'Expectation Failed',
+        422 => 'Unprocessable Entity',
 		429 => 'Too Many Requests',
 		500 => 'Internal Server Error',
 		501 => 'Not Implemented',

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Proxy\Tests;
+
+use Proxy\Http\Response;
+
+class ResponseTest extends \PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_returns_status_texts()
+    {
+        $response = new Response('', 200);
+
+        $this->assertEquals('OK', $response->getStatusText());
+    }
+
+    /** @test */
+    public function it_returns_status_texts_for_unknown_status_codes()
+    {
+        $response = new Response('', 199);
+
+        $this->assertEquals('Informational', $response->getStatusText());
+    }
+
+    /** @test */
+    public function it_returns_default_status_text_for_uncommon_status_codes()
+    {
+        $response = new Response('', 601);
+
+        $this->assertEquals('Unknown', $response->getStatusText());
+    }
+}


### PR DESCRIPTION
I am using your proxy and when my server returns a status code that is not within the array of known status codes, it will thrown an offset error. This pull request will provide a fallback and will return a default status text.

I also added some tests for the fix.
