### PR TITLE
Make sure we do not proxify our own proxy URL

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -147,20 +147,24 @@ function proxify_url($url, $base_url = ''){
 		$url = rel2abs($url, $base_url);
 	}
 	
-	// Make sure we do not proxy our proxy:
-	
-	// Extract the real host (without www.) from the two URLs
-	$host1 = preg_replace('/^www\./is', '', trim(parse_url($url, PHP_URL_HOST)));
-	$host2 = preg_replace('/^www\./is', '', trim(parse_url(app_url(), PHP_URL_HOST)));
-
-	// Make sure our proxy app host is not present in the URL to be proxified
-	if(strtolower($host1) == strtolower($host2) || stripos(".".$host1, $host2) ){
-		return $base_url;
+	// If $url is empty...
+	if(!$url){
+		return $base_url ? $base_url : app_url();
 	}
 	
-	// Make sure the schema is only http and https
-	if(!in_array(strtolower(parse_url($url, PHP_URL_SCHEME)), array('http', 'https'), true)){
-		return $base_url;
+	// Extract the real host (without www.) from $url and app_url()
+	$url_host = preg_replace('/^www\./is', '', trim(parse_url($url, PHP_URL_HOST)));
+	$app_host = preg_replace('/^www\./is', '', trim(parse_url(app_url(), PHP_URL_HOST)));
+
+	// Make sure the proxy app host is not present in the URL to be proxified
+	if(strtolower($url_host) == strtolower($app_host) || stripos(".".$url_host, $app_host) ){
+		// Maybe it would be better to show an error message?
+		return app_url();
+	}
+	
+	// Make sure the scheme is http, https, ftp
+	if(!in_array(strtolower(parse_url($url, PHP_URL_SCHEME)), array('http','https','ftp'), true)){
+		return $base_url ? $base_url : app_url();
 	}
 	
 	return app_url().'?q='.url_encrypt($url);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -159,7 +159,7 @@ function proxify_url($url, $base_url = ''){
 	}
 	
 	// Make sure the schema is only http and https
-	if(in_array(strtolower(parse_url($url, PHP_URL_SCHEME)), array('http', 'https'), true)){
+	if(!in_array(strtolower(parse_url($url, PHP_URL_SCHEME)), array('http', 'https'), true)){
 		return $base_url;
 	}
 	

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -158,6 +158,11 @@ function proxify_url($url, $base_url = ''){
 		return $base_url;
 	}
 	
+	// Make sure the schema is only http and https
+	if(in_array(strtolower(parse_url($url, PHP_URL_SCHEME)), array('http', 'https'), true)){
+		return $base_url;
+	}
+	
 	return app_url().'?q='.url_encrypt($url);
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -147,10 +147,16 @@ function proxify_url($url, $base_url = ''){
 		$url = rel2abs($url, $base_url);
 	}
 	
-	// Make sure we do not proxy ourself
-        if(stripos($url, app_url()) === 0){
-		return $url;
-        }
+	// Make sure we do not proxy our proxy:
+	
+	// Extract the real host (without www.) from the two URLs
+	$host1 = preg_replace('/^www\./is', '', trim(parse_url($url, PHP_URL_HOST)));
+	$host2 = preg_replace('/^www\./is', '', trim(parse_url(app_url(), PHP_URL_HOST)));
+
+	// Compare the two hosts (including subdomains) with our proxy URL
+	if(strtolower($host1) == strtolower($host2) || stripos(".".$host1, $host2) ){
+		return $base_url;
+	}
 	
 	return app_url().'?q='.url_encrypt($url);
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -153,7 +153,7 @@ function proxify_url($url, $base_url = ''){
 	$host1 = preg_replace('/^www\./is', '', trim(parse_url($url, PHP_URL_HOST)));
 	$host2 = preg_replace('/^www\./is', '', trim(parse_url(app_url(), PHP_URL_HOST)));
 
-	// Compare the two hosts (including subdomains) with our proxy URL
+	// Make sure our proxy app host is not present in the URL to be proxified
 	if(strtolower($host1) == strtolower($host2) || stripos(".".$host1, $host2) ){
 		return $base_url;
 	}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -147,6 +147,11 @@ function proxify_url($url, $base_url = ''){
 		$url = rel2abs($url, $base_url);
 	}
 	
+	// Make sure we do not proxy ourself
+        if(stripos($url, app_url()) === 0){
+		return $base_url;
+        }
+	
 	return app_url().'?q='.url_encrypt($url);
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -149,7 +149,7 @@ function proxify_url($url, $base_url = ''){
 	
 	// Make sure we do not proxy ourself
         if(stripos($url, app_url()) === 0){
-		return $base_url;
+		return $url;
         }
 	
 	return app_url().'?q='.url_encrypt($url);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -162,6 +162,20 @@ function proxify_url($url, $base_url = ''){
 		return app_url();
 	}
 	
+	// Make sure to not proxify localhost
+	if(strtolower($url_host) == "localhost" ){
+		// Maybe it would be better to show an error message?
+		return app_url();
+	}
+	
+	// Make sure to not proxify internal IP addresses
+	if(filter_var($url_host, FILTER_VALIDATE_IP)){
+		if(filter_var($url_host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false){
+			// Maybe it would be better to show an error message?
+			return app_url();
+		}
+	}
+	
 	// Make sure the scheme is http, https, ftp
 	if(!in_array(strtolower(parse_url($url, PHP_URL_SCHEME)), array('http','https','ftp'), true)){
 		return $base_url ? $base_url : app_url();


### PR DESCRIPTION
Inside function proxify_url($url, $base_url = '') we make sure that:
1) The proxy cannot proxify "itself".
2) Allow only http, https, ftp in scheme on $url.
3) Not proxify localhost and internal IP addresses.

Good improvements for security reasons.