### PR TITLE
Do not proxify mailto|tel|javascript on html_href()

### DIFF
--- a/src/Plugin/ProxifyPlugin.php
+++ b/src/Plugin/ProxifyPlugin.php
@@ -35,7 +35,7 @@ class ProxifyPlugin extends AbstractPlugin {
 		$url = trim($matches[2]);
 		
 		// do not proxify magnet: links
-		if(strpos($url, "magnet") === 0){
+		if(preg_match("/^(about|javascript|magnet|mailto|tel|ios-app|android-app)/i", $url)){
 			return $matches[0];
 		}
 		


### PR DESCRIPTION
```
		// do not proxify magnet: links
		if(preg_match("/^(about|javascript|magnet|mailto|tel|ios-app|android-app)/i", $url)){
			return $matches[0];
		}
```

So links like `href="mailto:a@b.com"` are not proxied.