### PR TITLE
Support url_pattern_regex (one plugin for more sites)

### DIFF
--- a/src/Plugin/AbstractPlugin.php
+++ b/src/Plugin/AbstractPlugin.php
@@ -10,6 +10,9 @@ abstract class AbstractPlugin implements EventSubscriberInterface {
 	// apply these methods only to those events whose request URL passes this filter
 	protected $url_pattern;
 	
+	// apply these methods only to those events whose request URL passes this filter (regex)
+	protected $url_pattern_regex;
+	
 	public function onBeforeRequest(ProxyEvent $event){
 		// fired right before a request is being sent to a proxy
 	}
@@ -33,6 +36,11 @@ abstract class AbstractPlugin implements EventSubscriberInterface {
 		
 		// url filter provided and current request url does not match it
 		if($this->url_pattern && strpos($url, $this->url_pattern) === false){
+			return;
+		}
+		
+		// url filter (regex) provided and current request url does not match it
+		if($this->url_pattern_regex && !preg_match($this->url_pattern_regex, $url)){
 			return;
 		}
 		

--- a/src/Plugin/AbstractPlugin.php
+++ b/src/Plugin/AbstractPlugin.php
@@ -10,9 +10,6 @@ abstract class AbstractPlugin implements EventSubscriberInterface {
 	// apply these methods only to those events whose request URL passes this filter
 	protected $url_pattern;
 	
-	// apply these methods only to those events whose request URL passes this filter (regex)
-	protected $url_pattern_regex;
-	
 	public function onBeforeRequest(ProxyEvent $event){
 		// fired right before a request is being sent to a proxy
 	}
@@ -35,13 +32,16 @@ abstract class AbstractPlugin implements EventSubscriberInterface {
 		$url = $event['request']->getUri();
 		
 		// url filter provided and current request url does not match it
-		if($this->url_pattern && strpos($url, $this->url_pattern) === false){
-			return;
-		}
-		
-		// url filter (regex) provided and current request url does not match it
-		if($this->url_pattern_regex && !preg_match($this->url_pattern_regex, $url)){
-			return;
+		if($this->url_pattern){
+		    if(strpos($this->url_pattern, '/') === 0){
+			    if(!preg_match($this->url_pattern, $url)) 
+				return;
+			} 
+			else
+			{
+			    if(stripos($url, $this->url_pattern) === false) 
+				return;
+			}
 		}
 		
 		switch($event->getName()){


### PR DESCRIPTION
Useful to create a plugin that handles more websites (i.e abc.com, abc.de, abc.eu, etc) or similar.