### PR TITLE
Remove the "integrity" attribute of some elements

### DIFF
--- a/src/Plugin/ProxifyPlugin.php
+++ b/src/Plugin/ProxifyPlugin.php
@@ -118,6 +118,9 @@ class ProxifyPlugin extends AbstractPlugin {
 		// <meta http-equiv="refresh" content="5; url=http://example.com/">
 		$str = preg_replace_callback('/content=(["\'])\d+\s*;\s*url=(.*?)\1/is', array($this, 'meta_refresh'), $str);
 		
+		// remove the "integrity" attribute of some elements - fix some website not rendering properly (like Github)
+		$str = preg_replace('/[^<(.*?)]integrity="(.*?)"/is', '', $str);
+		
 		return $str;
 	}
 	

--- a/src/Plugin/ProxifyPlugin.php
+++ b/src/Plugin/ProxifyPlugin.php
@@ -119,7 +119,7 @@ class ProxifyPlugin extends AbstractPlugin {
 		$str = preg_replace_callback('/content=(["\'])\d+\s*;\s*url=(.*?)\1/is', array($this, 'meta_refresh'), $str);
 		
 		// remove the "integrity" attribute of some elements - fix some website not rendering properly (like Github)
-		$str = preg_replace('/[^<(.*?)]integrity="(.*?)"/is', '', $str);
+		$str = preg_replace('/[^<(.*?)]integrity=(\'|")(.*?)(\'|")/is', '', $str);
 		
 		return $str;
 	}


### PR DESCRIPTION
I added a fix (a preg_replace) to remove the "integrity" attribute of some elements (like scripts, stylesheets, ...). That fix some websites not rendering properly (like Github).