### PR TITLE
Allow user to not proxify urls on setContent($output)

### DIFF
--- a/src/Plugin/ProxifyPlugin.php
+++ b/src/Plugin/ProxifyPlugin.php
@@ -147,6 +147,11 @@ class ProxifyPlugin extends AbstractPlugin {
 		
 		$str = $response->getContent();
 		
+		// DO NOT do any proxification if $event['donotproxify'] = true;
+		// Useful if on a plugin I do not want to proxify the urls within $event['response']->setContent($output);
+		// Because on $output I have inserted custom urls 
+		if($event['donotproxify']) return;
+		
 		// DO NOT do any proxification on .js files and text/plain content type
 		$no_proxify = array('text/javascript', 'application/javascript', 'application/x-javascript', 'text/plain');
 		if(in_array($content_type, $no_proxify)){

--- a/src/Plugin/ProxifyPlugin.php
+++ b/src/Plugin/ProxifyPlugin.php
@@ -150,6 +150,9 @@ class ProxifyPlugin extends AbstractPlugin {
 		// DO NOT do any proxification if $event['donotproxify'] = true;
 		// Useful if on a plugin I do not want to proxify the urls within $event['response']->setContent($output);
 		// Because on $output I have inserted custom urls 
+		// Here is an example usage:
+		// On a plugin's OnComplete() function, add $event['donotproxify'] = true;
+		// Before calling $event['response']->setContent($output);
 		if($event['donotproxify']) return;
 		
 		// DO NOT do any proxification on .js files and text/plain content type


### PR DESCRIPTION
Here is explaination:

// DO NOT do any proxification if $event['donotproxify'] = true;
// Useful if on a plugin I do not want to proxify the urls within $event['response']->setContent($output);
// Because on $output I have inserted custom urls 
if($event['donotproxify']) return;

You can use it like this on a plugin:

$event['donotproxify'] = true;
$event['response']->setContent($output);