### PR TITLE
ProxifyPlugin: Split content-type header on no_profixy check

### DIFF
--- a/src/Plugin/ProxifyPlugin.php
+++ b/src/Plugin/ProxifyPlugin.php
@@ -143,7 +143,7 @@ class ProxifyPlugin extends AbstractPlugin {
 		$url_host = parse_url($this->base_url, PHP_URL_HOST);
 		
 		$response = $event['response'];
-		$content_type = $response->headers->get('content-type');
+		$content_type = explode(';', $response->headers->get('content-type'), 2)[0];
 		
 		$str = $response->getContent();
 		


### PR DESCRIPTION
The Content-Type header can contain additional information like encoding,
separated by a semicolon. Since we only care about the media type, we can split
at the first semicolon and ignore the rest.