### PR TITLE
Fix content-type cleaning if provided an array

### DIFF
--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -46,7 +46,7 @@ class Proxy {
 			$value = trim($parts[1]);
 			
 			// this must be a header: value line
-			$this->response->headers->set($name, $value, false);
+			$this->response->headers->set($name, $value, true);
 			
 		} else if($this->status_found){
 		

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -2,11 +2,16 @@
 
 use Proxy\Config;
 
-// strip away extra parameters text/html; charset=UTF-8
-function clean_content_type($content_type){
-	return trim(preg_replace('@;.*@', '', $content_type));
+/**
+ * Strip away extra parameters "text/html; charset=UTF-8"
+ * @param $content_type
+ * @return string
+ */
+function clean_content_type($content_type)
+{
+    $content_type = (is_array($content_type) && count($content_type) > 0) ? $content_type[0] : $content_type;
+    return trim(preg_replace('@;.*@', '', $content_type));
 }
-
 
 if(!function_exists('starts_with')){
 	


### PR DESCRIPTION
If you are enabling following through curl  (`CURLOPT_FOLLOWLOCATION`), sometimes the content-types will stack up into an array and needs to be reduced to a single string. Without this checking, you will run into a Fatal Error.